### PR TITLE
Make defrost power a function of cooling cop (not constant)

### DIFF
--- a/resdx/conditions.py
+++ b/resdx/conditions.py
@@ -1,0 +1,39 @@
+from .psychrometrics import PsychState, STANDARD_CONDITIONS, psychrolib
+from .units import fr_u
+
+class OperatingConditions:
+  def __init__(self, outdoor=STANDARD_CONDITIONS,
+                     indoor=STANDARD_CONDITIONS,
+                     compressor_speed=0):
+    self.outdoor = outdoor
+    self.indoor = indoor
+    self.compressor_speed = compressor_speed # compressor speed index (0 = full speed, 1 = next lowest, ...)
+    self.rated_air_flow_set = False
+
+  def set_rated_air_flow(self, air_vol_flow_per_rated_cap, net_total_cooling_capacity_rated):
+    self.net_total_cooling_capacity_rated = net_total_cooling_capacity_rated
+    self.std_air_vol_flow_rated = air_vol_flow_per_rated_cap*net_total_cooling_capacity_rated
+    self.air_vol_flow_rated = self.std_air_vol_flow_rated*STANDARD_CONDITIONS.get_rho()/self.indoor.get_rho()
+    self.air_mass_flow_rated = self.air_vol_flow_rated*self.indoor.get_rho()
+    self.rated_air_flow_set = True
+    self.set_air_flow(self.air_vol_flow_rated)
+
+  def set_air_flow(self, air_vol_flow):
+    self.air_vol_flow = air_vol_flow
+    self.air_mass_flow = air_vol_flow*self.indoor.get_rho()
+    if self.rated_air_flow_set:
+      self.std_air_vol_flow = self.air_mass_flow/STANDARD_CONDITIONS.get_rho()
+      self.air_mass_flow_fraction = self.air_mass_flow/self.air_mass_flow_rated
+      self.std_air_vol_flow_per_capacity = self.std_air_vol_flow/self.net_total_cooling_capacity_rated
+
+class CoolingConditions(OperatingConditions):
+  def __init__(self,outdoor=PsychState(drybulb=fr_u(95.0,"°F"),wetbulb=fr_u(75.0,"°F")),
+                    indoor=PsychState(drybulb=fr_u(80.0,"°F"),wetbulb=fr_u(67.0,"°F")),
+                    compressor_speed=0):
+    super().__init__(outdoor, indoor, compressor_speed)
+
+class HeatingConditions(OperatingConditions):
+  def __init__(self,outdoor=PsychState(drybulb=fr_u(47.0,"°F"),wetbulb=fr_u(43.0,"°F")),
+                    indoor=PsychState(drybulb=fr_u(70.0,"°F"),wetbulb=fr_u(60.0,"°F")),
+                    compressor_speed=0):
+    super().__init__(outdoor, indoor, compressor_speed)

--- a/resdx/dx_unit.py
+++ b/resdx/dx_unit.py
@@ -1,10 +1,10 @@
-#%%
 import sys
 from enum import Enum
 import math
 from scipy import optimize
 
-from .psychrometrics import PsychState, STANDARD_CONDITIONS, psychrolib
+from .psychrometrics import PsychState, psychrolib
+from .conditions import HeatingConditions, CoolingConditions
 from .defrost import Defrost, DefrostControl, DefrostStrategy
 from .units import fr_u, to_u
 from .util import calc_biquad, calc_quad, find_nearest
@@ -17,44 +17,6 @@ def interpolate(f, cond_1, cond_2, x):
 class CyclingMethod(Enum):
   BETWEEN_LOW_FULL = 1
   BETWEEN_OFF_FULL = 2
-
-#%%
-class OperatingConditions:
-  def __init__(self, outdoor=STANDARD_CONDITIONS,
-                     indoor=STANDARD_CONDITIONS,
-                     compressor_speed=0):
-    self.outdoor = outdoor
-    self.indoor = indoor
-    self.compressor_speed = compressor_speed # compressor speed index (0 = full speed, 1 = next lowest, ...)
-    self.rated_air_flow_set = False
-
-  def set_rated_air_flow(self, air_vol_flow_per_rated_cap, net_total_cooling_capacity_rated):
-    self.net_total_cooling_capacity_rated = net_total_cooling_capacity_rated
-    self.std_air_vol_flow_rated = air_vol_flow_per_rated_cap*net_total_cooling_capacity_rated
-    self.air_vol_flow_rated = self.std_air_vol_flow_rated*STANDARD_CONDITIONS.get_rho()/self.indoor.get_rho()
-    self.air_mass_flow_rated = self.air_vol_flow_rated*self.indoor.get_rho()
-    self.rated_air_flow_set = True
-    self.set_air_flow(self.air_vol_flow_rated)
-
-  def set_air_flow(self, air_vol_flow):
-    self.air_vol_flow = air_vol_flow
-    self.air_mass_flow = air_vol_flow*self.indoor.get_rho()
-    if self.rated_air_flow_set:
-      self.std_air_vol_flow = self.air_mass_flow/STANDARD_CONDITIONS.get_rho()
-      self.air_mass_flow_fraction = self.air_mass_flow/self.air_mass_flow_rated
-      self.std_air_vol_flow_per_capacity = self.std_air_vol_flow/self.net_total_cooling_capacity_rated
-
-class CoolingConditions(OperatingConditions):
-  def __init__(self,outdoor=PsychState(drybulb=fr_u(95.0,"°F"),wetbulb=fr_u(75.0,"°F")),
-                    indoor=PsychState(drybulb=fr_u(80.0,"°F"),wetbulb=fr_u(67.0,"°F")),
-                    compressor_speed=0):
-    super().__init__(outdoor, indoor, compressor_speed)
-
-class HeatingConditions(OperatingConditions):
-  def __init__(self,outdoor=PsychState(drybulb=fr_u(47.0,"°F"),wetbulb=fr_u(43.0,"°F")),
-                    indoor=PsychState(drybulb=fr_u(70.0,"°F"),wetbulb=fr_u(60.0,"°F")),
-                    compressor_speed=0):
-    super().__init__(outdoor, indoor, compressor_speed)
 
 # AHRI 210/240 2017 distributions
 class HeatingDistribution:

--- a/resdx/models/nrel.py
+++ b/resdx/models/nrel.py
@@ -80,7 +80,10 @@ class NRELDXModel(DXModel):
     if system.model_data["cooling_cop60"][conditions.compressor_speed] is not None:
       return system.model_data["cooling_cop60"][conditions.compressor_speed]
     else:
-      condition = system.make_condition(CoolingConditions,outdoor=PsychState(drybulb=fr_u(60.0,"°F"),wetbulb=fr_u(48.0,"°F")),compressor_speed=conditions.compressor_speed)
+      condition = system.make_condition(CoolingConditions,
+                                        outdoor=PsychState(drybulb=fr_u(60.0,"°F"),wetbulb=fr_u(48.0,"°F")),  # 60 F at ~40% RH
+                                        indoor=PsychState(drybulb=fr_u(70.0,"°F"),wetbulb=fr_u(60.0,"°F")),  # Use H1 indoor conditions (since we're still heating)
+                                        compressor_speed=conditions.compressor_speed)
       system.model_data["cooling_cop60"][conditions.compressor_speed] = system.gross_cooling_cop(condition)
       return system.model_data["cooling_cop60"][conditions.compressor_speed]
 
@@ -98,7 +101,7 @@ class NRELDXModel(DXModel):
         #T_iwb = to_u(conditions.indoor.wb,"°C")
         #T_odb = conditions.outdoor.db_C
         # defEIRfT = calc_biquad([0.1528, 0, 0, 0, 0, 0], T_iwb, T_odb) # Assumption from BEopt 0.1528 = 1/gross_cop_cooling(60F)
-        defEIRfT = 1/NRELDXModel.get_cooling_cop60(conditions, system)
+        defEIRfT = 1/NRELDXModel.get_cooling_cop60(conditions, system)  # Assume defrost EIR is constant (maybe it could/should change with indoor conditions?)
         P_defrost = defEIRfT*(system.gross_heating_capacity_rated[conditions.compressor_speed]/1.01667)
       else:
         P_defrost = system.defrost.resistive_power

--- a/test/test_resdx.py
+++ b/test/test_resdx.py
@@ -47,7 +47,7 @@ def test_2_speed_regression():
   assert dx_unit_2_speed.seer() == approx(17, 0.01)
   assert dx_unit_2_speed.eer() == approx(13, 0.01)
   assert dx_unit_2_speed.hspf() == approx(9.3, 0.01)
-  assert dx_unit_2_speed.hspf(region=2) == approx(13.6, 0.01)
+  assert dx_unit_2_speed.hspf(region=2) == approx(13.8, 0.01)
 
 def test_plot():
   # Plot integrated power and capacity


### PR DESCRIPTION
This address the question of where the `0.1528` constant comes from in NREL's integrated heating power function. It turns out that this was `1/gross_cop_cooling(60F)` for a specific unit. Now this value is calculated depending on the COP of the actual unit.