### PR TITLE
Fix fan error

### DIFF
--- a/resdx/enums.py
+++ b/resdx/enums.py
@@ -1,6 +1,12 @@
 from enum import Enum
 
 
+class FanMotorType(Enum):
+    UNKNOWN = 0
+    PSC = 1
+    BPM = 2
+
+
 class StagingType(Enum):
     SINGLE_STAGE = 1
     TWO_STAGE = 2

--- a/resdx/fan.py
+++ b/resdx/fan.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-from enum import Enum
 from math import exp, inf, log
 from random import Random
 
@@ -8,6 +7,7 @@ from koozie import convert, fr_u, to_u
 from numpy import array, linspace
 from scipy import optimize  # Used for finding system/fan curve intersection
 
+from .enums import FanMotorType
 from .util import calc_quad
 
 
@@ -25,12 +25,6 @@ class FanMetadata:
         self.notes = notes
         self.uuid_seed = uuid_seed
         self.data_version = data_version
-
-
-class FanMotorType(Enum):
-    UNKNOWN = 0
-    PSC = 1
-    BPM = 2
 
 
 class Fan:

--- a/resdx/models/unified_resnet.py
+++ b/resdx/models/unified_resnet.py
@@ -393,7 +393,7 @@ class RESNETDXModel(DXUnit):
 
             fan_design_airflow = self.rated_cooling_airflow[cfs]
 
-            if self.motor_type is None:
+            if self.motor_type is None or self.motor_type == FanMotorType.UNKNOWN:
                 if self.staging_type == StagingType.SINGLE_STAGE:
                     self.motor_type = FanMotorType.PSC
                 else:

--- a/resdx/models/unified_resnet.py
+++ b/resdx/models/unified_resnet.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from enum import Enum
 from typing import Callable
 
 from koozie import fr_u, to_u
@@ -7,7 +6,7 @@ from koozie import fr_u, to_u
 from ..conditions import CoolingConditions, HeatingConditions
 from ..defrost import Defrost
 from ..dx_unit import AHRIVersion, DXUnit
-from ..enums import StagingType
+from ..enums import FanMotorType, StagingType
 from ..fan import RESNETBPMFan, RESNETPSCFan
 from ..psychrometrics import cooling_psych_state, heating_psych_state
 from ..util import make_list, set_default
@@ -20,11 +19,6 @@ from .tabular_data import (
     make_two_speed_model_data,
 )
 from .title24 import Title24DXModel
-
-
-class FanMotorType(Enum):
-    PSC = 1
-    BPM = 2
 
 
 class RESNETDXModel(DXUnit):


### PR DESCRIPTION
I encountered a bug when passing in `FanMotorType` into `RESNETDXModel` in [cse-resnet-ref](https://github.com/bigladder/cse-resnet-ref/pull/11). There are two different `FanMotorType` enums in `resdx`, and apparently I picked the one that throws an error in `resdx/models/unified_resnet.py`.

I consolidated the `FanMotorType` enums into a single enum. The difference between the two enums is that one of them had `UNKNOWN = 0`, whereas the other one did not.

Let me know if my changes are okay, or if you want to go in a different direction.